### PR TITLE
채팅 시작시 이름 보여주기 - 깨달은 부분!

### DIFF
--- a/front/src/components/modal/Chatting.vue
+++ b/front/src/components/modal/Chatting.vue
@@ -1,8 +1,7 @@
 <template>
     <v-container  class="wrapper">
         <v-row >
-            userName
-            <!-- {{userName}} -->
+            {{userName}}
         </v-row>
         <br> <br>
         <v-row>
@@ -29,16 +28,45 @@
 
 </template>
 <script>
-
+/* eslint-disable */
 export default {
-    data(){
-        return{
-            msg : ''
-        }
+    created () {
     },
     props : [
-        'data'
+        'data',
+        'roomName',
+        'chatHistory'
     ],
+    computed : {
+        userData : function(){
+            return  this.$store.getters.auth_get_data;
+        },
+        userName : function(){
+            const a = this.data.nickName;
+            const b= this.data.target.nickName;
+            let res;
+            this.userData.nickName === a ? res =b : res = a;
+            console.log(res)
+            return res;
+            
+            // const userData = new Promise((resolve, reject)=> {
+            //     resolve(this.$store.getters.auth_get_data);
+            // })
+            // userData.then((userData)=> {
+            //     const a = this.data.nickName;
+            //     const b= this.data.target.nickName;
+            //     console.log(this.data)
+            //     let res;
+            //     // userData.nickName === a ? res =b : res = a;
+            //     return res;
+            // })
+        },
+    },
+    data() {
+        return {
+            msg : '',
+        }
+    }, 
     methods : {
         async sendMsg(){
             console.log(this.data)

--- a/front/src/store/modules/chatting.js
+++ b/front/src/store/modules/chatting.js
@@ -16,7 +16,7 @@ const chattingSocketModule = {
         joinRooms.push({
           roomName:data.roomName,
           chatHistory: [],
-          targetUserIdx: ''
+          data : data,
         })
         state.joinRooms = joinRooms;
       }

--- a/front/src/views/core/Home.vue
+++ b/front/src/views/core/Home.vue
@@ -91,7 +91,11 @@
             </v-col>
         </v-row>
         <v-row v-if="joinRooms.length > 0" class="chatting" id="pc_main">
-            <Chatting v-for="(joinRoom,index) in this.joinRooms" :key ="index" :data="joinRoom"></Chatting>
+            <Chatting v-for="(item,index) in this.joinRooms" :key ="index" 
+                :data="item.data"
+                :roomName = "item.roomName"
+                :chatHistory = "item.chatHistory"
+            />
         </v-row>
 
         <!-- mobile row -->


### PR DESCRIPTION
v-for문으로 만든 자식 컴포넌트에서 (item,key)로 넘겨주는데 이때 item을 그냥 data:'item'으로 전부 넘겨버리게 되면은 observer 객체로 리턴해줌. data:item.data 이런 식으로 세분화 시켜서 나누어 주면은 이런 오류가 없어짐!